### PR TITLE
feat 관리자 계정의 유저 권한 변경 추가

### DIFF
--- a/backend/src/main/java/com/malnutrition/backend/domain/admin/controller/AdminUserController.java
+++ b/backend/src/main/java/com/malnutrition/backend/domain/admin/controller/AdminUserController.java
@@ -1,8 +1,15 @@
 package com.malnutrition.backend.domain.admin.controller;
 
 
-import com.malnutrition.backend.domain.admin.dto.UserRoleUpdateRequestDto;
+import com.malnutrition.backend.domain.admin.dto.TrainerVerificationRequestDto;
+import com.malnutrition.backend.domain.admin.dto.UserCertificationVerificationRequestDto;
+import com.malnutrition.backend.domain.admin.enums.TrainerVerificationResult;
+import com.malnutrition.backend.domain.admin.service.AdminUserService;
+import com.malnutrition.backend.domain.certification.usercertification.enums.ApproveStatus;
 import com.malnutrition.backend.global.rp.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,25 +17,60 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Admin User API", description = "관리자용 사용자 관리 API")
 @RestController
-@RequestMapping("/api/vi/admin/users")
+@RequestMapping("/api/v1/admin/users")
 @RequiredArgsConstructor
 @Slf4j
 @PreAuthorize("hasRole('ADMIN')")
 public class AdminUserController {
 
-    // private final AdminUserService adminUserService;
+    private final AdminUserService adminUserService;
 
+    @Operation(
+            summary = "사용자 자격증 검토 상태 변경",
+            description = "관리자가 특정 사용자 자격증의 검토 상태(예: 승인, 반려)와 사유를 업데이트합니다.",
+            tags = {"Admin User Management"}
+    )
+    @PatchMapping("/certifications/{certificationId}/status")
+    public ResponseEntity<ApiResponse<Void>> updateUserCertificationStatus(
+            @PathVariable("certificationId") Long certificationId,
+            @Valid @RequestBody UserCertificationVerificationRequestDto requestDto
+            ) {
 
-    @PutMapping("/{userId}/role-update")
-    public ResponseEntity<ApiResponse<Void>> updateUserRole(
-            @PathVariable("userId") Long userId,
-            @Valid @RequestBody UserRoleUpdateRequestDto requestDto) {
+        adminUserService.updateUserCertificationVerificationStatus(certificationId, requestDto);
 
-        // TODO: adminUserService.updateUserRoleAndCertificationStatus(userId, requestDto) 호출
+        String message = "";
+        ApproveStatus newStatus = requestDto.getReviewStatus();
 
-        return ResponseEntity.ok(ApiResponse.success(null, "사용자 역할 변경 완료"));
+        if (newStatus == ApproveStatus.APPROVAL)
+            message = String.format("사용자 자격증(ID: %d)이 성공적으로 승인되었습니다.", certificationId);
+        else if (newStatus == ApproveStatus.DISAPPROVAL)
+            message = String.format("사용자 자격증(ID: %d)이 반려되었습니다.", certificationId);
 
+        return ResponseEntity.ok(ApiResponse.success(null, message));
 
     }
+
+    @Operation(
+            summary = "트레이너 자격 검증 및 결정",
+            description = "관리자가 특정 사용자의 트레이너 자격을 최종적으로 승인하거나 반려합니다.",
+            tags = {"Admin User Management"}
+    )
+    @PutMapping("/{userId}/trainer-verification")
+    public ResponseEntity<ApiResponse<Void>> decideTrainerVerification(
+            @PathVariable("userId") Long userId,
+            @Valid @RequestBody TrainerVerificationRequestDto requestDto) {
+
+        adminUserService.decideTrainerVerification(userId, requestDto);
+
+        String message = requestDto.getResult() == TrainerVerificationResult.APPROVE_AS_TRAINER ?
+                                                "트레이너 자격 검증 결과 승인이 완료되었습니다.":
+                                                "트레이너 자격 검증 결과 요청이 반려되었습니다.";
+
+        return ResponseEntity.ok(ApiResponse.success(null,message));
+
+    }
+
+
 }

--- a/backend/src/main/java/com/malnutrition/backend/domain/admin/controller/AdminUserController.java
+++ b/backend/src/main/java/com/malnutrition/backend/domain/admin/controller/AdminUserController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/v1/admin/users")
 @RequiredArgsConstructor
 @Slf4j
-@PreAuthorize("hasRole('ADMIN')")
+@PreAuthorize("hasRole('ROLE_ADMIN')")
 public class AdminUserController {
 
     private final AdminUserService adminUserService;

--- a/backend/src/main/java/com/malnutrition/backend/domain/admin/controller/AdminUserController.java
+++ b/backend/src/main/java/com/malnutrition/backend/domain/admin/controller/AdminUserController.java
@@ -1,0 +1,34 @@
+package com.malnutrition.backend.domain.admin.controller;
+
+
+import com.malnutrition.backend.domain.admin.dto.UserRoleUpdateRequestDto;
+import com.malnutrition.backend.global.rp.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/vi/admin/users")
+@RequiredArgsConstructor
+@Slf4j
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminUserController {
+
+    // private final AdminUserService adminUserService;
+
+
+    @PutMapping("/{userId}/role-update")
+    public ResponseEntity<ApiResponse<Void>> updateUserRole(
+            @PathVariable("userId") Long userId,
+            @Valid @RequestBody UserRoleUpdateRequestDto requestDto) {
+
+        // TODO: adminUserService.updateUserRoleAndCertificationStatus(userId, requestDto) 호출
+
+        return ResponseEntity.ok(ApiResponse.success(null, "사용자 역할 변경 완료"));
+
+
+    }
+}

--- a/backend/src/main/java/com/malnutrition/backend/domain/admin/dto/TrainerVerificationRequestDto.java
+++ b/backend/src/main/java/com/malnutrition/backend/domain/admin/dto/TrainerVerificationRequestDto.java
@@ -1,0 +1,18 @@
+package com.malnutrition.backend.domain.admin.dto;
+
+import com.malnutrition.backend.domain.admin.enums.TrainerVerificationResult;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class TrainerVerificationRequestDto {
+
+    @NotNull(message = "트레이너 검증 결과는 필수입니다.")
+    private TrainerVerificationResult result;
+
+    private String reason;
+}

--- a/backend/src/main/java/com/malnutrition/backend/domain/admin/dto/UserCertificationVerificationRequestDto.java
+++ b/backend/src/main/java/com/malnutrition/backend/domain/admin/dto/UserCertificationVerificationRequestDto.java
@@ -9,11 +9,10 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
-public class UserRoleUpdateRequestDto {
+public class UserCertificationVerificationRequestDto {
 
-    @NotNull(message = "처리할 사용자 자격증 ID는 필수")
-    private Long userCertificationId;
+    @NotNull(message = "변경할 검토 상태는 필수입니다.")
+    private ApproveStatus reviewStatus;
 
-    @NotNull(message = "변경할 승인 상태는 필수")
-    private ApproveStatus targetApproveStatus;
+    private String reason;
 }

--- a/backend/src/main/java/com/malnutrition/backend/domain/admin/dto/UserRoleUpdateRequestDto.java
+++ b/backend/src/main/java/com/malnutrition/backend/domain/admin/dto/UserRoleUpdateRequestDto.java
@@ -1,0 +1,19 @@
+package com.malnutrition.backend.domain.admin.dto;
+
+import com.malnutrition.backend.domain.certification.usercertification.enums.ApproveStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class UserRoleUpdateRequestDto {
+
+    @NotNull(message = "처리할 사용자 자격증 ID는 필수")
+    private Long userCertificationId;
+
+    @NotNull(message = "변경할 승인 상태는 필수")
+    private ApproveStatus targetApproveStatus;
+}

--- a/backend/src/main/java/com/malnutrition/backend/domain/admin/enums/TrainerVerificationResult.java
+++ b/backend/src/main/java/com/malnutrition/backend/domain/admin/enums/TrainerVerificationResult.java
@@ -1,0 +1,6 @@
+package com.malnutrition.backend.domain.admin.enums;
+
+public enum TrainerVerificationResult {
+    APPROVE_AS_TRAINER,
+    REJECT_AS_TRAINER
+}

--- a/backend/src/main/java/com/malnutrition/backend/domain/admin/log/entity/TrainerVerificationLog.java
+++ b/backend/src/main/java/com/malnutrition/backend/domain/admin/log/entity/TrainerVerificationLog.java
@@ -1,0 +1,37 @@
+package com.malnutrition.backend.domain.admin.log.entity;
+
+import com.malnutrition.backend.domain.admin.enums.TrainerVerificationResult;
+import com.malnutrition.backend.domain.user.user.entity.User;
+import com.malnutrition.backend.global.jpa.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
+
+@Entity
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Table(name = "trainer_verification_log")
+public class TrainerVerificationLog extends BaseEntity {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "admin_user_id", nullable = true)
+    private User adminUser;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TrainerVerificationResult decision;
+
+    @Column(columnDefinition = "TEXT")
+    private String reason;
+
+    @Column(nullable = false)
+    private LocalDateTime processedAt;
+}

--- a/backend/src/main/java/com/malnutrition/backend/domain/admin/log/repository/TrainerVerificationLogRepository.java
+++ b/backend/src/main/java/com/malnutrition/backend/domain/admin/log/repository/TrainerVerificationLogRepository.java
@@ -1,0 +1,14 @@
+package com.malnutrition.backend.domain.admin.log.repository;
+
+import com.malnutrition.backend.domain.admin.log.entity.TrainerVerificationLog;
+import com.malnutrition.backend.domain.user.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.*;
+
+@Repository
+public interface TrainerVerificationLogRepository extends JpaRepository<TrainerVerificationLog, Long> {
+    List<TrainerVerificationLog> findByUserOrderByProcessedAtDesc(User user);
+    Optional<TrainerVerificationLog> findTopByUserOrderByProcessedAtDesc(User user);
+}

--- a/backend/src/main/java/com/malnutrition/backend/domain/admin/service/AdminUserService.java
+++ b/backend/src/main/java/com/malnutrition/backend/domain/admin/service/AdminUserService.java
@@ -1,0 +1,14 @@
+package com.malnutrition.backend.domain.admin.service;
+
+import com.malnutrition.backend.domain.certification.usercertification.entity.UserCertification;
+import com.malnutrition.backend.domain.user.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdminUserService {
+
+    private final UserRepository userRepository;
+    private final UserCertification
+}

--- a/backend/src/main/java/com/malnutrition/backend/domain/admin/service/AdminUserService.java
+++ b/backend/src/main/java/com/malnutrition/backend/domain/admin/service/AdminUserService.java
@@ -1,14 +1,129 @@
 package com.malnutrition.backend.domain.admin.service;
 
+import com.malnutrition.backend.domain.admin.dto.TrainerVerificationRequestDto;
+import com.malnutrition.backend.domain.admin.dto.UserCertificationVerificationRequestDto;
+import com.malnutrition.backend.domain.admin.enums.TrainerVerificationResult;
+import com.malnutrition.backend.domain.admin.log.entity.TrainerVerificationLog;
+import com.malnutrition.backend.domain.admin.log.repository.TrainerVerificationLogRepository;
 import com.malnutrition.backend.domain.certification.usercertification.entity.UserCertification;
+import com.malnutrition.backend.domain.certification.usercertification.enums.ApproveStatus;
+import com.malnutrition.backend.domain.certification.usercertification.repository.UserCertificationRepository;
+import com.malnutrition.backend.domain.user.user.entity.User;
+import com.malnutrition.backend.domain.user.user.enums.Role;
 import com.malnutrition.backend.domain.user.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AdminUserService {
 
     private final UserRepository userRepository;
-    private final UserCertification
+    private final UserCertificationRepository userCertificationRepository;
+    private final TrainerVerificationLogRepository trainerVerificationLogRepository;
+
+
+    @Transactional
+    public void updateUserCertificationVerificationStatus(Long userCertificationId, UserCertificationVerificationRequestDto requestDto) {
+        UserCertification userCertification = userCertificationRepository.findById(userCertificationId)
+                .orElseThrow(() -> new EntityNotFoundException("ID " + userCertificationId + "에 해당하는 사용자 자격증 정보를 찾을 수 없습니다."));
+
+        ApproveStatus oldStatus = userCertification.getApproveStatus();
+        ApproveStatus newStatus = requestDto.getReviewStatus();
+        String reason = requestDto.getReason();
+
+        userCertification.setApproveStatus(newStatus);
+
+        log.info("관리자 활동: UserCertification ID [{}]의 검토 상태 변경. 이전 상태: [{}], 새 상태: [{}], 사유: [{}]",
+                userCertificationId, oldStatus, newStatus, (reason != null && !reason.isBlank() ? reason : "별도 사유 없음"));
+
+        if(reason != null && !reason.isBlank())
+            userCertification.setAdminComment(reason);
+
+    }
+
+    @Transactional
+    public void decideTrainerVerification(Long userId, TrainerVerificationRequestDto requestDto) {
+        User targetUser = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("ID " + userId + "에 해당하는 사용자를 찾을 수 없습니다."));
+
+        TrainerVerificationResult result = requestDto.getResult();
+        String reason = requestDto.getReason();
+
+        User adminUser = getCurrentAdminUser();
+        String reasonForLog;
+
+        if (reason != null && !reason.isBlank()) {
+            reasonForLog = reason;
+        } else {
+            // 입력된 사유가 없을 경우
+            reasonForLog = (result == TrainerVerificationResult.APPROVE_AS_TRAINER)
+                    ? "자격 요건 충족으로 트레이너 자격이 승인되었습니다."
+                    : "트레이너 자격 요건이 충족되지 않았거나 기타 사유로 반려되었습니다";
+        }
+
+        Role oldRole = targetUser.getRole(); // 현재 역할 기록
+        Role newRole = oldRole;
+
+        if(result == TrainerVerificationResult.APPROVE_AS_TRAINER) {
+            if (oldRole != Role.TRAINER) {
+                targetUser.setRole(Role.TRAINER); // 역할을 TRAINER로 변경
+                newRole = Role.TRAINER;
+                log.info("관리자 활동: 관리자 ID [{}](으)로 인해 사용자 ID [{}]의 역할이 [{}]에서 [TRAINER](으)로 변경되었습니다. 사유: [{}]",
+                        adminUser.getEmail(), userId, oldRole, reasonForLog);
+            } else {
+                log.info("관리자 활동: 관리자 ID [{}](이)가 트레이너 자격을 승인했으나, 사용자 ID [{}]는 이미 TRAINER 역할입니다. 사유: [{}]",
+                        adminUser.getEmail(), userId, reasonForLog);
+            }
+        } else {
+            log.info("관리자 활동: 관리자 ID [{}](이)가 사용자 ID [{}]의 트레이너 자격을 반려했습니다. 사유: [{}]",
+                    adminUser.getEmail(), userId, reasonForLog);
+        }
+
+        TrainerVerificationLog verificationLog = TrainerVerificationLog.builder()
+                .user(targetUser)
+                .adminUser(adminUser)
+                .decision(result)
+                .reason(reasonForLog)
+                .processedAt(LocalDateTime.now())
+                .build();
+
+
+
+        trainerVerificationLogRepository.save(verificationLog);
+
+
+
+    }
+
+    private User getCurrentAdminUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if(authentication == null || !authentication.isAuthenticated() || "anonymousUser".equals(authentication.getPrincipal())) {
+            throw new AccessDeniedException("인증된 사용자 정보가 없거나 유효하지 않음");
+        }
+        String adminEmail = authentication.getName();
+
+        User adminUser = userRepository.findByEmail(adminEmail)
+                .orElseThrow(() -> new UsernameNotFoundException("관리자 계정(" + adminEmail + ")을 DB 에서 찾을 수 없음."));
+
+        boolean isAdmin = adminUser.getRole() == Role.ADMIN;
+        if(!isAdmin)
+            throw new AccessDeniedException("사용자(" + adminEmail + ")는 관리자 권한(ROLE_ADMIN)이 없습니다.");
+
+        return adminUser;
+
+    }
+
+
 }

--- a/backend/src/main/java/com/malnutrition/backend/domain/certification/usercertification/entity/UserCertification.java
+++ b/backend/src/main/java/com/malnutrition/backend/domain/certification/usercertification/entity/UserCertification.java
@@ -17,6 +17,8 @@ import java.time.LocalDateTime;
 @SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
+@Getter
+@Setter
 @Table(name = "user_certifications")
 public class UserCertification extends BaseEntity {
 
@@ -39,4 +41,8 @@ public class UserCertification extends BaseEntity {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "certification_image_id")
     private Image image; //자격증 이미지
+
+    @Column(columnDefinition = "TEXT") // 승인, 반려 사유 (관리자 입력)
+    private String adminComment;
+
 }

--- a/backend/src/main/java/com/malnutrition/backend/global/app/DataLoader.java
+++ b/backend/src/main/java/com/malnutrition/backend/global/app/DataLoader.java
@@ -27,7 +27,7 @@ public class DataLoader implements CommandLineRunner {
     @Transactional
     public void run(String... args) throws Exception {
         if(!userService.isExistProvider("SYSTEM")){
-            String email = "join@test.com";
+            String email = "admin@health-school.com";
             String nickname = "joinUser";
             String phoneNumber = "010-1111-2222";
             UserJoinRequestDto dto = UserJoinRequestDto.builder()


### PR DESCRIPTION
관리자 계정의 유저 자격증 승인 및 권한 변경 기능 구현

1. 유저 자격증에 대한 개별 승인 (승인 / 반려와 함께 해당 결정에 대한 코멘트 작성 기능 추가)
2. 유저의 트레이너 신청에 대한 최종 승인 (승인 / 반려와 함께 해당 결정에 관리자의 코멘트 작성 및 요청 이력 관련 DB추가)
   